### PR TITLE
Rewrite to propagate metadata internally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         - if: ${{ matrix.architecture != 'x86_64'}}
           run: nix build .#${{matrix.architecture}}.${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input nix-proto github:notalltim/upstream-apis/${{ matrix.style }}
         - if: ${{ matrix.architecture == 'x86_64'}}
-          run: nix build .#${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}}
+          run: nix build .#${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input nix-proto github:notalltim/upstream-apis/${{ matrix.style }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
             repository: notalltim/test-apis
             ref: refs/heads/${{ matrix.style }}
         - if: ${{ matrix.architecture != 'x86_64'}}
-          run: nix build .#${{matrix.architecture}}.${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input nix-proto github:notalltim/upstream-apis/${{ matrix.style }}
+          run: nix build .#${{matrix.architecture}}.${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input upstream-apis github:notalltim/upstream-apis/${{ matrix.style }}
         - if: ${{ matrix.architecture == 'x86_64'}}
-          run: nix build .#${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input nix-proto github:notalltim/upstream-apis/${{ matrix.style }}
+          run: nix build .#${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input upstream-apis github:notalltim/upstream-apis/${{ matrix.style }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         package: [tester]
         type: [grpc]
         language: [cpp, py]
-        style: [legacy-meta main]
+        style: [legacy-meta, main]
     steps:
         - uses: cachix/install-nix-action@v23
         - name: Get branch names

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [22.05, 22.11, 23.05]
+        version: [22.05, 22.11, 23.05, 23.11]
         architecture: [x86_64]
         package: [tester]
         type: [grpc]
         language: [cpp, py]
+        style: [legacy-meta main]
     steps:
         - uses: cachix/install-nix-action@v23
         - name: Get branch names
@@ -27,7 +28,7 @@ jobs:
         - uses: actions/checkout@v4
           with:
             repository: notalltim/test-apis
-            ref: refs/heads/main
+            ref: refs/heads/${{ matrix.style }}
         - if: ${{ matrix.architecture != 'x86_64'}}
           run: nix build .#${{matrix.architecture}}.${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}}
         - if: ${{ matrix.architecture == 'x86_64'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
             repository: notalltim/test-apis
             ref: refs/heads/${{ matrix.style }}
         - if: ${{ matrix.architecture != 'x86_64'}}
-          run: nix build .#${{matrix.architecture}}.${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}}
+          run: nix build .#${{matrix.architecture}}.${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}} --override-input nix-proto github:notalltim/upstream-apis/${{ matrix.style }}
         - if: ${{ matrix.architecture == 'x86_64'}}
           run: nix build .#${{ matrix.package }}_${{matrix.type}}_${{matrix.language}} --override-input nix-proto github:notalltim/nix-proto/${{steps.branch-name.outputs.current_branch}} --override-input nixpkgs github:NixOS/nixpkgs/release-${{ matrix.version}}

--- a/default.nix
+++ b/default.nix
@@ -1,80 +1,23 @@
 { nix_lib
 , std
 , filter
-}: rec {
-  common = rec {
-    inherit (lib.strings) splitString concatStringsSep;
-    inherit (lib.lists) fold flatten concatMap unique;
-    toProtocInclude = x: fold (a: b: "-I=" + toString (a.src) + " " + b) "" x;
-    recursiveDeps = deps: concatMap (y: (if builtins.length y.protoDeps != 0 then [ (recursiveDeps y.protoDeps) ] else [ ]) ++ [ y ]) deps;
-    recursiveProtoDeps = deps: unique ((flatten (recursiveDeps deps)));
-    slashToUnderscore = namespace: concatStringsSep "_" (splitString "/" namespace);
+}:
+let
+
+  __internal_lib = import ./lib.nix { inherit filter; lib = nix_lib; };
+  inherit (__internal_lib) utilities;
+
+  lib = std // nix_lib // __internal_lib.common;
+
+  generation = import ./generation.nix { inherit lib; };
+
+  #TODO(notalltim): remove this when downstream not using it
+  legacy = import ./legacy.nix { inherit filter; inherit lib; generateDerivations = generation.generateDerivations; };
+in
+{
+  inherit (legacy) generateMeta generateOverlay generateOverlays;
+  inherit (generation) mkProtoDerivation generateOverlays';
+  lib = {
+    inherit (utilities) srcFromNamespace nameFromNamespace overlayToList;
   };
-
-  lib = std // nix_lib // common;
-
-  generateMeta = { name ? "", dir, version, protoDeps, namespace ? "" }:
-    {
-      name = if namespace == "" then name else (lib.slashToUnderscore namespace);
-      src = filter {
-        root = dir;
-        include = [
-          (if namespace == "" then name else namespace)
-        ];
-      };
-      version = version;
-      protoDeps = protoDeps;
-    };
-
-  generateProto = { meta }:
-    let
-      proto = (import ./proto) { inherit meta; inherit lib; };
-    in
-    proto.package;
-
-  generatePython = { meta }:
-    let
-      python = (import ./python) { inherit meta; inherit lib; };
-    in
-    python.proto_package;
-
-  generateGRPCPython = { meta }:
-    let
-      python = (import ./python) { inherit meta; inherit lib; };
-    in
-    python.grpc_package;
-
-  generateCpp = { meta }:
-    let
-      cpp = (import ./cpp) { inherit meta; inherit lib; };
-    in
-    cpp.package_protobuf;
-
-  generateGRPCCpp = { meta }:
-    let
-      cpp = (import ./cpp) { inherit meta; inherit lib; };
-    in
-    cpp.package_grpc;
-
-  generateDerivations = { meta }: rec {
-    ${meta.name + "_proto_" + "drv"} = generateProto { inherit meta; };
-    ${meta.name + "_proto_" + "py_drv"} = generatePython { inherit meta; };
-    ${meta.name + "_grpc_" + "py_drv"} = generateGRPCPython { inherit meta; };
-    ${meta.name + "_proto_" + "cpp_drv"} = generateCpp { inherit meta; };
-    ${meta.name + "_grpc_" + "cpp_drv"} = generateGRPCCpp { inherit meta; };
-  };
-
-  generateOverlay = { meta }:
-    let
-      derivations = generateDerivations { inherit meta; };
-      inherit (lib.attrsets) mapAttrs' nameValuePair;
-      inherit (lib.strings) removeSuffix;
-    in
-    final: prev: (mapAttrs' (key: value: nameValuePair (removeSuffix "_drv" key) (prev.callPackage value { })) derivations);
-
-  generateOverlays = { metas }:
-    let
-      inherit (lib.lists) forEach;
-    in
-    forEach metas (meta: (generateOverlay { inherit meta; }));
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nix-filter": {
       "locked": {
-        "lastModified": 1694857738,
-        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
+        "lastModified": 1701697642,
+        "narHash": "sha256-L217WytWZHSY8GW9Gx1A64OnNctbuDbfslaTEofXXRw=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
+        "rev": "c843418ecfd0344ecb85844b082ff5675e02c443",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nix-std": {
       "locked": {
-        "lastModified": 1685917625,
-        "narHash": "sha256-2manVKofCZrCToVDnDYNvtYUFBYOM5JhdDoNGVY4fq4=",
+        "lastModified": 1701658249,
+        "narHash": "sha256-KIt1TUuBvldhaVRta010MI5FeQlB8WadjqljybjesN0=",
         "owner": "chessai",
         "repo": "nix-std",
-        "rev": "e20af8822b5739434b875643bfc61fe0195ea2fb",
+        "rev": "715db541ffff4194620e48d210b76f73a74b5b5d",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698795814,
-        "narHash": "sha256-HFjjlZY62hUdWYjnyRdAy7OoNChpC0zqiqVXAIcQFCw=",
+        "lastModified": 1703336516,
+        "narHash": "sha256-tubahnvhR0RmdCFtMtNEYKc88zKefapmm5+wykVMvCM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "864814c092a7b9965104ce0b6639dc986350050b",
+        "rev": "78bcced5a04aa6911a0d93cb25ff6599ca2f97c6",
         "type": "github"
       },
       "original": {

--- a/generation.nix
+++ b/generation.nix
@@ -1,0 +1,57 @@
+{ lib }: rec {
+
+  mkProtoDerivation = in_set: { stdenvNoCC }: stdenvNoCC.mkDerivation (in_set // {
+    version = if in_set ? version then in_set.version else "0.0.0";
+    propagatedBuildInputs = in_set.protoDeps;
+    installPhase = ''
+      runHook preInstall
+      cp -r . $out
+      runHook postInstall
+    '';
+    #TODO(notalltim): Add user generation options
+    # - allow user to control language specific naming through suffix
+    # - allow the user to specify a install namespace that does not match source
+  });
+
+  generateOverlays' = drv_set:
+    let
+      inherit (lib.attrsets) mapAttrs' nameValuePair;
+    in
+    mapAttrs' (name: drv: nameValuePair (name + "_overlay") (__generateOverlay' { inherit drv; inherit name; })) drv_set;
+
+  # Proto derivation (Deprecated)
+  __generateProto = ((import ./proto) { inherit lib; }).package;
+  # Python Generation
+  __pythonGenerators = (import ./python) { inherit lib; };
+  __generatePython = __pythonGenerators.gen_protobuf;
+  __generateGRPCPython = __pythonGenerators.gen_grpc;
+  # Cpp Generation
+  __cppGenerators = (import ./cpp) { inherit lib; };
+  __generateCpp = __cppGenerators.gen_protobuf;
+  __generateGRPCCpp = __cppGenerators.gen_grpc;
+
+  generateDerivations = { name }: rec {
+    ${name + "_proto_" + "drv"} = __generateProto;
+    ${name + "_proto_" + "py_drv"} = __generatePython;
+    ${name + "_grpc_" + "py_drv"} = __generateGRPCPython;
+    ${name + "_proto_" + "cpp_drv"} = __generateCpp;
+    ${name + "_grpc_" + "cpp_drv"} = __generateGRPCCpp;
+  };
+
+  __evaluateProtoDerivation = input:
+    let
+      inherit (lib.trivial) functionArgs;
+      doubleCall = !((functionArgs input) ? stdenvNoCC); # Check if the user passed a function or if this is the internal derivation
+    in
+    if doubleCall then prev: (prev.callPackage (prev.callPackage input { }) { }) else prev: (prev.callPackage input { });
+
+  __generateOverlay' = { drv, name }:
+    let
+      inherit (lib.attrsets) mapAttrs' nameValuePair;
+      inherit (lib.strings) removeSuffix;
+      package = __evaluateProtoDerivation drv;
+      derivations = (generateDerivations { inherit name; });
+    in
+    final: prev: (mapAttrs' (key: value: nameValuePair (removeSuffix "_drv" key) (prev.callPackage value { __proto_internal_meta_package = package prev; })) derivations)
+      // rec { ${name} = package prev; };
+}

--- a/legacy.nix
+++ b/legacy.nix
@@ -1,0 +1,42 @@
+{ lib
+, filter
+, generateDerivations
+}: rec {
+  #TODO(notalltim): remove when all down stream users are changed over
+  generateMeta = { name ? "", dir, version, protoDeps, namespace ? "" }:
+    lib.trivial.warn "generateMeta is deprecated and will be removed in the future please use mkProtoDerivation" {
+      name = if namespace == "" then name else (lib.slashToUnderscore namespace);
+      src = filter {
+        root = dir;
+        include = [
+          (if namespace == "" then name else namespace)
+        ];
+      };
+      version = version;
+      protoDeps = protoDeps;
+    };
+
+  #TODO(notalltim): remove when `generateMeta` is removed
+  __metaCompat = meta': { stdenvNoCC }: stdenvNoCC.mkDerivation meta' // {
+    name = meta'.name;
+    version = meta'.name;
+    proto_meta = meta';
+  };
+
+  #TODO(notalltim): repurpose when `generateMeta` is removed
+  generateOverlay = { meta }:
+    let
+      inherit (lib.attrsets) mapAttrs' nameValuePair;
+      inherit (lib.strings) removeSuffix;
+      package = prev: prev.callPackage (__metaCompat meta) {};
+      derivations = lib.trivial.warn "generateOverlay is deprecated and will work differently in a future release please use mkProtoDerivation and generateOverlays'" (generateDerivations { name = meta.name; });
+    in
+    final: prev: (mapAttrs' (key: value: nameValuePair (removeSuffix "_drv" key) (prev.callPackage value { __proto_internal_meta_package = (package prev); })) derivations);
+
+  #TODO(notalltim): remove when `generateMeta` is removed
+  generateOverlays = { metas }:
+    let
+      inherit (lib.lists) forEach;
+    in
+    forEach metas (meta: (generateOverlay { inherit meta; }));
+}

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,44 @@
+{ lib
+, filter
+}:
+let
+  inherit (lib.strings) splitString concatStringsSep;
+  inherit (lib.lists) fold flatten concatMap unique;
+  inherit (builtins) length;
+  inherit (lib.attrsets) mapAttrsToList;
+
+  common = rec {
+    toProtocInclude = x: fold (a: b: "-I=" + toString (a.src) + " " + b) "" x;
+    recursiveDeps = deps: concatMap (y: (if length y.protoDeps != 0 then [ (recursiveDeps y.protoDeps) ] else [ ]) ++ [ y ]) deps;
+    recursiveProtoDeps = deps: unique ((flatten (recursiveDeps deps)));
+    slashToUnderscore = namespace: concatStringsSep "_" (splitString "/" namespace);
+
+    tryLoadMeta = storePath:
+      # TODO(notalltim): remove when `generateMeta` is removed
+      if storePath ? proto_meta then storePath.proto_meta else
+      let
+        deps = storePath.propagatedBuildInputs;
+        meta = {
+          name = storePath.name;
+          version = storePath.version;
+          src = storePath.outPath;
+          protoDeps = concatMap (path: [ (tryLoadMeta path) ]) deps;
+        };
+      in
+      meta;
+  };
+
+  utilities = {
+    srcFromNamespace = { root, namespace }: filter {
+      inherit root;
+      include = [
+        namespace
+      ];
+    };
+    nameFromNamespace = namespace: common.slashToUnderscore namespace;
+    overlayToList = overlay_set: mapAttrsToList (name: overlay: overlay) overlay_set;
+  };
+in
+{
+  inherit common utilities;
+}

--- a/proto/default.nix
+++ b/proto/default.nix
@@ -1,8 +1,9 @@
-{ meta, lib }: rec {
+{ lib }: rec {
   inherit (lib.lists) forEach;
   toBuildDeps = x: pkgs: forEach x (dep: pkgs.${dep.name + "_proto"});
 
-  package = { stdenvNoCC, pkgs }: stdenvNoCC.mkDerivation rec {
+  package = { stdenvNoCC, pkgs, __proto_internal_meta_package }: stdenvNoCC.mkDerivation rec {
+    meta = (lib.tryLoadMeta __proto_internal_meta_package);
     name = meta.name + "_proto";
     src = meta.src;
     version = meta.version;

--- a/python/default.nix
+++ b/python/default.nix
@@ -1,4 +1,4 @@
-{ meta, lib }: rec {
+{ lib }: rec {
   inherit (lib.lists) forEach;
   inherit (lib.strings) escapeShellArg concatMapStringsSep;
   inherit (lib) recursiveProtoDeps toProtocInclude;
@@ -6,23 +6,22 @@
   toPythonDependencies = x: forEach x (a: builtins.toString (a.name + "_proto_py") + ">=" + builtins.toString (a.version));
   toPyProjectTOML = (import ./pyproj.nix) { inherit lib; };
   toBuildDepsPy = x: pkgs: forEach x (a: pkgs.${a.name + "_proto_py"});
-  protoDeps = recursiveProtoDeps meta.protoDeps;
 
 
 
-  package = { python310Packages, protobuf, pkgs, suffix, inputPatchPhase, buildInputs, inputDependencies }: python310Packages.buildPythonPackage rec {
-    name = meta.name + suffix;
-    version = meta.version;
-    src = meta.src;
+  package = { python310Packages, protobuf, pkgs, suffix, inputPatchPhase, buildInputs, inputDependencies, proto_meta}: python310Packages.buildPythonPackage rec {
+    name = proto_meta.name + suffix;
+    version = proto_meta.version;
+    src = proto_meta.src;
 
-    buildDeps = [ python310Packages.protobuf ] ++ (toBuildDepsPy meta.protoDeps pkgs) ++ buildInputs;
+    buildDeps = [ python310Packages.protobuf ] ++ (toBuildDepsPy proto_meta.protoDeps pkgs) ++ buildInputs;
     nativeBuildInputs = [ protobuf python310Packages.setuptools ] ++ buildDeps; # for import checking
     propagatedBuildInputs = buildDeps;
     doCheck = false;
 
     pyproject = true;
 
-    dependencies = inputDependencies ++ [ "protobuf" ] ++ toPythonDependencies meta.protoDeps;
+    dependencies = inputDependencies ++ [ "protobuf" ] ++ toPythonDependencies proto_meta.protoDeps;
     py_project_toml = toPyProjectTOML { inherit name; inherit version; inherit dependencies; };
 
     prePatch = ''
@@ -31,13 +30,13 @@
     patchPhase = inputPatchPhase;
     postPatch = ''
       shopt -s globstar
-      declare -A deps=${escapeShellArg("(" + (concatMapStringsSep " " (dep: "[\"" +  dep.name + "\"]" + "=\"" + dep.src + "\"")  (protoDeps ++ [ meta ])) + ")")}
+      declare -A deps=${escapeShellArg("(" + (concatMapStringsSep " " (dep: "[\"" +  dep.name + "\"]" + "=\"" + dep.src + "\"")  ((recursiveProtoDeps proto_meta.protoDeps) ++ [ proto_meta ])) + ")")}
       # Prefix all the imports with the container package
       echo "Patching proto imports"
       for dep in "''${!deps[@]}"; do
           for proto in `find "''${deps[''${dep}]}" -type f -name "*.proto"`; do
             path=$(realpath --relative-to="''${deps[''${dep}]}" "$proto" | sed 's/\.[^.]*$//;s/[/]/./g;s/*[.]\././;s/\.[^.]*$//')
-            for py in `find "./src/${meta.name + suffix}" -type f -name "*_pb2*.py"`; do
+            for py in `find "./src/${proto_meta.name + suffix}" -type f -name "*_pb2*.py"`; do
               sed -i "s/from\ $path\ import/from\ ''${dep}_proto_py.$path\ import/g" $py
           done
         done
@@ -52,18 +51,19 @@
     '';
   };
 
-  proto_package = { python310Packages, protobuf, pkgs }: package rec {
+  gen_protobuf = { python310Packages, protobuf, pkgs , __proto_internal_meta_package}: package rec {
     inherit python310Packages;
     inherit protobuf;
     inherit pkgs;
+    proto_meta = (lib.tryLoadMeta __proto_internal_meta_package);
     suffix = "_proto_py";
     inputPatchPhase =
       ''
         runHook prePatch
         shopt -s globstar
-        for proto in `find "${meta.src}" -type f -name "*.proto"`; do
-          protoc ${(toProtocInclude (protoDeps ++ [ meta ]))} --python_out=src/${meta.name + suffix} $proto
-          echo  "from .$(realpath --relative-to="${meta.src}" "$proto" | sed 's/\.[^.]*$//;s/[/]/./g;s/*[.]\././')_pb2 import *" >> src/${meta.name + suffix}/__init__.py
+        for proto in `find "${proto_meta.src}" -type f -name "*.proto"`; do
+          protoc ${(toProtocInclude ((recursiveProtoDeps proto_meta.protoDeps) ++ [ proto_meta ]))} --python_out=src/${proto_meta.name + suffix} $proto
+          echo  "from .$(realpath --relative-to="${proto_meta.src}" "$proto" | sed 's/\.[^.]*$//;s/[/]/./g;s/*[.]\././')_pb2 import *" >> src/${proto_meta.name + suffix}/__init__.py
         done
         runHook postPatch
       '';
@@ -71,20 +71,21 @@
     buildInputs = [ ];
   };
 
-  grpc_package = { python310Packages, protobuf, pkgs, grpc, openssl, zlib, stdenv }: package rec {
+  gen_grpc = { python310Packages, protobuf, pkgs, grpc, openssl, zlib, stdenv, __proto_internal_meta_package }: package rec {
     inherit python310Packages;
     inherit protobuf;
     inherit pkgs;
+    proto_meta = (lib.tryLoadMeta __proto_internal_meta_package);
     suffix = "_grpc_py";
-    buildInputs = [ python310Packages.grpcio python310Packages.grpcio-tools grpc openssl zlib stdenv ] ++ (toBuildDepsPy [ meta ] pkgs);
+    buildInputs = [ python310Packages.grpcio python310Packages.grpcio-tools grpc openssl zlib stdenv ] ++ (toBuildDepsPy [ proto_meta ] pkgs);
     inputDependencies = [ "grpcio" ];
     inputPatchPhase =
       ''
         runHook prePatch
         shopt -s globstar
-        for proto in `find "${meta.src}" -type f -name "*.proto"`; do
-          python -m grpc_tools.protoc ${ (toProtocInclude (protoDeps ++ [ meta ]))} --grpc_python_out=src/${meta.name + suffix} $proto
-          echo  "from .$(realpath --relative-to="${meta.src}" "$proto" | sed 's/\.[^.]*$//;s/[/]/./g;s/*[.]\././')_pb2_grpc import *" >> src/${meta.name + suffix}/__init__.py
+        for proto in `find "${proto_meta.src}" -type f -name "*.proto"`; do
+          python -m grpc_tools.protoc ${ (toProtocInclude ((recursiveProtoDeps proto_meta.protoDeps) ++ [ proto_meta ]))} --grpc_python_out=src/${proto_meta.name + suffix} $proto
+          echo  "from .$(realpath --relative-to="${proto_meta.src}" "$proto" | sed 's/\.[^.]*$//;s/[/]/./g;s/*[.]\././')_pb2_grpc import *" >> src/${proto_meta.name + suffix}/__init__.py
         done
         runHook postPatch
       '';


### PR DESCRIPTION
This rewrite removes the need to propagate the "meta" attribute sets produced by  `generateMeta` as flake outputs. It handles this by internally creating by adding the `mkProtoDerivation` function and allowing the user to pass function as input.

**Externally**:
- `mkProtoDerivation` is used to add a layer of indirection on the `stdenvNoCC.mkDerivation` call so the user can pas metadata and options that are not know until evaluation.
- `generateOverlays'` takes an attribute set of functions or attribute sets and produces an attribute set of overlays that contains the generated packages.
- This commit maintains backwards compatibility with the previous `generateMeta` based workflow.

**Internally:**
- Codgen packages no longet take the meta attribute set as input they instead have input package `__proto_internal_meta_package` (yes the name is awful) that allows them to retrieve the meta data about the protos at evaluation time.
- The internals have been reorganized into multiple files to help with read ability and maintainability.
- Source filtering and naming are exported as utilities under the lib attribute set.
- The  `generateMeta` based workflow also uses the new codegen interface under the hood.