### PR TITLE
Remove the on push to prevent extra CI runs

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -11,3 +11,13 @@ jobs:
     uses: ./.github/workflows/build-multiple.yml
     with:
         branch: ${{ matrix.branches }}
+  it-all-good:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - build-supported-releases
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -1,8 +1,5 @@
 name: "PR Validation"
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
CI was running when a PR got merged due to the on push trigger in github ci