### PR TITLE
Fix python import patching for no namespace proto

### DIFF
--- a/python/default.nix
+++ b/python/default.nix
@@ -119,7 +119,10 @@
             for proto in `find "''${deps[''${dep}]}" -type f -name "*.proto"`; do
               path=$(realpath --relative-to="''${deps[''${dep}]}" "$proto" | sed 's/\.[^.]*$//;s/[/]/./g;s/*[.]\././;s/\.[^.]*$//')
               for py in `find "./src/${proto_meta.name + suffix}" -type f -name "*_pb2*.py"`; do
+                # Handle the case where there is a namespace for the proto
                 sed -i "s/from\ $path\ import/from\ ''${dep}_proto_py.$path\ import/g" $py
+                # Handle the imports when there is no namespace
+                sed -i "s/import\ $path/from\ ''${dep}_proto_py\ import $path/g" $py
             done
           done
         done


### PR DESCRIPTION
The previous sed expression only handled imports of the form `from x.x.x import x_pb2` when there is no namespace instead substitute for the import form of `import x_pb2 as ...`