### PR TITLE
Switch to final from prev for overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The nix-proto library provides automatic overlay generation and dependency manag
 
 **NOTE** only tested with `x86_64-linux` as the `buildPlatform`
 
-![aarch64-multiplatform](https://github.com/notalltim/nix-proto/actions/workflows/aarch64-multiplatform/badge.svg) ![armv7-hf-multiplatform](https://github.com/notalltim/nix-proto/actions/workflows/armv7-hf-multiplatform/badge.svg)
+![aarch64-multiplatform](https://github.com/notalltim/nix-proto/actions/workflows/aarch64-multiplatform.yml/badge.svg) ![armv7-hf-multiplatform](https://github.com/notalltim/nix-proto/actions/workflows/armv7-hf-multiplatform.yml/badge.svg)
 
 ## Features
 
@@ -33,7 +33,7 @@ Code generation dependencies are managed on a per language basis i.e. if there a
 
 ### Utilities
 
-There are a few utilities provides to help using the `mkProtoDerivation` . They can be found under `nix-proto.lib`
+There are a few utilities provides to help with the `mkProtoDerivation` function. They can be found under `nix-proto.lib`
 
 - `overlayToList` - convert the overlay returned from the `generateOverlays'` call to a list
 - `srcFromNamespace` - given a folder structure for a proto filter the given root to allow for multiple apis to be co-located

--- a/generation.nix
+++ b/generation.nix
@@ -212,8 +212,8 @@
     doubleCall = !((functionArgs input) ? stdenvNoCC); # Check if the user passed a function or if this is the internal derivation
   in
     if doubleCall
-    then prev: (prev.callPackage (prev.callPackage input {}) {})
-    else prev: (prev.callPackage input {});
+    then final: (final.callPackage (final.callPackage input {}) {})
+    else final: (final.callPackage input {});
 
   /*
   *
@@ -256,7 +256,7 @@
     package = evaluateProtoDerivation drv;
     derivations = generateDerivations {inherit name;};
   in
-    final: prev:
-      (mapAttrs' (key: value: nameValuePair (removeSuffix "_drv" key) (prev.callPackage value {__proto_internal_meta_package = package prev;})) derivations)
-      // rec {${name} = package prev;};
+    final: _:
+      (mapAttrs' (key: value: nameValuePair (removeSuffix "_drv" key) (final.callPackage value {__proto_internal_meta_package = package final;})) derivations)
+      // rec {${name} = package final;};
 }


### PR DESCRIPTION
Switch from prev to final because the overlay is not overriding anything so there is no need to reference the previous package set. This should be a slight speed up in overlay evaluation.

- Switch from prev to final
- Fix incorrect url for badge
- Fix spacing/grammar issue in readme