### PR TITLE
Add a generation target for proto descriptors

### DIFF
--- a/.github/workflows/aarch64-multiplatform.yml
+++ b/.github/workflows/aarch64-multiplatform.yml
@@ -9,3 +9,4 @@ jobs:
     with:
       branch: release-23.11
       architecture: armv7l-hf-multiplatform
+      build_legacy: false

--- a/.github/workflows/armv7-hf-multiplatform.yml
+++ b/.github/workflows/armv7-hf-multiplatform.yml
@@ -9,3 +9,4 @@ jobs:
     with:
       branch: release-23.11
       architecture: armv7l-hf-multiplatform
+      build_legacy: false

--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -39,7 +39,7 @@ jobs:
           branch: ${{ steps.branch-name.outputs.current_branch }}
           architecture: ${{ inputs.architecture }}
       - name: Build Legacy
-        if: ${{ build_legacy }} == true
+        if: ${{ inputs.build_legacy }} == true
         uses: ./action/.github/actions/build
         with:
           nixpkgs: ${{ inputs.branch }}

--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -9,6 +9,10 @@ on:
         type: string
         required: false
         default: "x86-64"
+      build_legacy:
+        type: boolean
+        required: false
+        default: true
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
       matrix:
         package: [tester]
         type: [grpc]
-        language: [cpp, py]
+        language: [cpp, py, proto_descriptor]
         style: [legacy-meta, main]
     steps:
       - name: Get branch names
@@ -26,10 +30,20 @@ jobs:
         with:
           path: action
           ref: refs/heads/${{ steps.branch-name.outputs.current_branch }}
-      - uses: ./action/.github/actions/build
+      - name: Build
+        uses: ./action/.github/actions/build
         with:
           nixpkgs: ${{ inputs.branch }}
-          style: ${{ matrix.style }}
+          style: main
+          generator: ${{ matrix.type }}_${{ matrix.language }}
+          branch: ${{ steps.branch-name.outputs.current_branch }}
+          architecture: ${{ inputs.architecture }}
+      - name: Build Legacy
+        if: build_legacy == true
+        uses: ./action/.github/actions/build
+        with:
+          nixpkgs: ${{ inputs.branch }}
+          style: legacy-meta
           generator: ${{ matrix.type }}_${{ matrix.language }}
           branch: ${{ steps.branch-name.outputs.current_branch }}
           architecture: ${{ inputs.architecture }}

--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -39,7 +39,7 @@ jobs:
           branch: ${{ steps.branch-name.outputs.current_branch }}
           architecture: ${{ inputs.architecture }}
       - name: Build Legacy
-        if: build_legacy == true
+        if: ${{ build_legacy }} == true
         uses: ./action/.github/actions/build
         with:
           nixpkgs: ${{ inputs.branch }}

--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         package: [tester]
-        language: [grpc_cpp, grcp_py, proto_descriptor]
+        language: [grpc_cpp, grpc_py, proto_descriptor]
     steps:
       - name: Get branch names
         id: branch-name

--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -21,7 +21,6 @@ jobs:
         package: [tester]
         type: [grpc]
         language: [cpp, py, proto_descriptor]
-        style: [legacy-meta, main]
     steps:
       - name: Get branch names
         id: branch-name

--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -19,8 +19,7 @@ jobs:
     strategy:
       matrix:
         package: [tester]
-        type: [grpc]
-        language: [cpp, py, proto_descriptor]
+        language: [grpc_cpp, grcp_py, proto_descriptor]
     steps:
       - name: Get branch names
         id: branch-name
@@ -34,7 +33,7 @@ jobs:
         with:
           nixpkgs: ${{ inputs.branch }}
           style: main
-          generator: ${{ matrix.type }}_${{ matrix.language }}
+          generator: ${{ matrix.language }}
           branch: ${{ steps.branch-name.outputs.current_branch }}
           architecture: ${{ inputs.architecture }}
       - name: Build Legacy
@@ -43,6 +42,6 @@ jobs:
         with:
           nixpkgs: ${{ inputs.branch }}
           style: legacy-meta
-          generator: ${{ matrix.type }}_${{ matrix.language }}
+          generator: ${{ matrix.language }}
           branch: ${{ steps.branch-name.outputs.current_branch }}
           architecture: ${{ inputs.architecture }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,9 +3,8 @@ on:
   schedule:
     - cron: '12 6 * * *'
   workflow_dispatch:
-
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-        branch: master
+      branch: master

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       branch: ${{ matrix.branches }}
       architecture: ${{ matrix.architectures }}
+      build_legacy: false
   it-all-good:
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/release-22.05.yml
+++ b/.github/workflows/release-22.05.yml
@@ -2,9 +2,8 @@ name: "22.05 "
 on:
   workflow_dispatch:
   workflow_call:
-
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-        branch: release-22.05
+      branch: release-22.05

--- a/.github/workflows/release-22.11.yml
+++ b/.github/workflows/release-22.11.yml
@@ -1,9 +1,8 @@
 name: "22.11 "
 on:
   workflow_dispatch:
-
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-        branch: release-22.11
+      branch: release-22.11

--- a/.github/workflows/release-23.05.yml
+++ b/.github/workflows/release-23.05.yml
@@ -3,9 +3,8 @@ on:
   schedule:
     - cron: '12 6 * * *'
   workflow_dispatch:
-
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-        branch: release-23.05
+      branch: release-23.05

--- a/.github/workflows/release-23.11.yml
+++ b/.github/workflows/release-23.11.yml
@@ -3,9 +3,8 @@ on:
   schedule:
     - cron: '12 6 * * *'
   workflow_dispatch:
-
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-        branch: release-23.11
+      branch: release-23.11

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -3,9 +3,8 @@ on:
   schedule:
     - cron: '12 6 * * *'
   workflow_dispatch:
-
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-        branch: nixpkgs-unstable
+      branch: nixpkgs-unstable

--- a/descriptor/default.nix
+++ b/descriptor/default.nix
@@ -1,0 +1,66 @@
+{lib}: rec {
+  inherit (lib.lists) forEach;
+  inherit (lib) recursiveProtoDeps toProtocInclude loadMeta;
+
+  /*
+    *
+  Convert a set of attribute sets of metadata to a list of derivations looked up by name from the package set provided.
+
+    # Type
+
+    ```
+    toBuildDeps :: List -> List
+    ```
+
+    - [deps] List of attribute sets minimally containing the name of the base proto.
+    - [pkgs] List of attribute sets minimally containing the name of the base proto.
+
+    - [returns] List of derivations from the package set that the package depends on.
+
+  */
+  toBuildDeps = deps: pkgs: forEach deps (dep: pkgs.${dep.name + "_proto_descriptor"});
+
+  /*
+  *
+  Constructs a derivation to create the proto descriptors for a given folder of protos.
+
+  # Type
+
+  ```
+  package :: { pkgs :: AttrSet, __proto_internal_meta_package :: Derivation } -> (AttrSet -> Derivation)
+  ```
+
+  - [pkgs] Package set that this derivation will be built into.
+  - [__proto_internal_meta_package] The derivation holding the metadata and source location for the protos (dependencies etc.)
+  */
+  package = {
+    pkgs,
+    __proto_internal_meta_package,
+    protobuf,
+  }:
+    pkgs.stdenvNoCC.mkDerivation rec {
+      meta = loadMeta __proto_internal_meta_package;
+      name = meta.name + "_proto_descriptor";
+      src = meta.src;
+      version = meta.version;
+      nativeBuildInputs = [protobuf];
+      propagatedBuildInputs = toBuildDeps meta.protoDeps pkgs;
+
+      prePatch = ''
+        for proto in `find "${meta.src}" -type f -name "*.proto"`; do
+          # TODO: look into whether include imports is needed it is a bit heavy handed
+          protoc  --include_imports \
+                  --descriptor_set_out=$(realpath --relative-to="${meta.src}" "$proto" | sed 's/\.[^.]*$//g').desc \
+                  ${(toProtocInclude ((recursiveProtoDeps meta.protoDeps) ++ [meta]))} $proto;
+        done
+      '';
+
+      installPhase = ''
+        shopt -s globstar
+        runHook preInstall
+        mkdir -p $out
+        cp --parents -R ./**/*.desc $out
+        runHook postInstall
+      '';
+    };
+}

--- a/generation.nix
+++ b/generation.nix
@@ -154,6 +154,12 @@
   generateGRPCCpp = cppGenerators.grpc;
 
   /*
+  * Generate proto descriptors
+  */
+
+  generateDescriptor = ((import ./descriptor) {inherit lib;}).package;
+
+  /*
   *
   Create a set of derivation to evaluate with `generateOverlay'`
   # Example
@@ -179,6 +185,7 @@
     ${name + "_grpc_" + "py_drv"} = generateGRPCPython;
     ${name + "_proto_" + "cpp_drv"} = generateCpp;
     ${name + "_grpc_" + "cpp_drv"} = generateGRPCCpp;
+    ${name + "_proto_" + "descriptor_drv"} = generateDescriptor;
   };
 
   /*


### PR DESCRIPTION
Generate the proto descriptors and install then in the same file structure as the given proto. The descriptor uses `--include-impports` but this should be evaluated.