### PR TITLE
Add support for exporting descriptors for python

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -7,7 +7,7 @@ jobs:
   build-supported-releases:
     strategy:
       matrix:
-        branches: [release-22.05, release-22.11, release-23.05, release-23.11, nixpkgs-unstable, master]
+        branches: [release-22.11, release-23.05, release-23.11, nixpkgs-unstable, master]
     uses: ./.github/workflows/build-multiple.yml
     with:
       branch: ${{ matrix.branches }}

--- a/.github/workflows/release-22.05.yml
+++ b/.github/workflows/release-22.05.yml
@@ -1,9 +1,0 @@
-name: "22.05 "
-on:
-  workflow_dispatch:
-  workflow_call:
-jobs:
-  build-releases:
-    uses: ./.github/workflows/build-multiple.yml
-    with:
-      branch: release-22.05

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The nix-proto library provides automatic overlay generation and dependency manag
 
 ## Supported Releases
 
-![release-22.05](https://github.com/notalltim/nix-proto/actions/workflows/release-22.05.yml/badge.svg) ![release-22.11](https://github.com/notalltim/nix-proto/actions/workflows/release-22.11.yml/badge.svg) ![release-23.05](https://github.com/notalltim/nix-proto/actions/workflows/release-23.05.yml/badge.svg) ![release-23.11](https://github.com/notalltim/nix-proto/actions/workflows/release-23.11.yml/badge.svg) ![unstable](https://github.com/notalltim/nix-proto/actions/workflows/unstable.yml/badge.svg) ![master](https://github.com/notalltim/nix-proto/actions/workflows/master.yml/badge.svg)
+![release-22.11](https://github.com/notalltim/nix-proto/actions/workflows/release-22.11.yml/badge.svg) ![release-23.05](https://github.com/notalltim/nix-proto/actions/workflows/release-23.05.yml/badge.svg) ![release-23.11](https://github.com/notalltim/nix-proto/actions/workflows/release-23.11.yml/badge.svg) ![unstable](https://github.com/notalltim/nix-proto/actions/workflows/unstable.yml/badge.svg) ![master](https://github.com/notalltim/nix-proto/actions/workflows/master.yml/badge.svg)
 
 ## Supported Cross Compile
 

--- a/python/descriptor.py
+++ b/python/descriptor.py
@@ -1,0 +1,22 @@
+from functools import cache
+from importlib.resources import files
+from pathlib import Path
+from typing import List
+
+from google.protobuf.descriptor_pb2 import (FileDescriptorProto,
+                                            FileDescriptorSet)
+
+
+@cache
+def file_descriptor_set() -> List[FileDescriptorProto]:
+    file_descriptors = []
+    with files("@package@").joinpath("descriptors.txt").open("r") as f:
+        for line in f:
+            for descriptor_file_set_path in Path(str(line)).rglob("*.desc"):
+                with open(descriptor_file_set_path, "rb") as file_descriptor:
+                    file_descriptor_set = FileDescriptorSet.FromString(
+                        file_descriptor.read()
+                    )
+                    for descriptor in file_descriptor_set.file:
+                        file_descriptors.append(descriptor)
+    return file_descriptors

--- a/python/pyproj.nix
+++ b/python/pyproj.nix
@@ -14,4 +14,8 @@ lib.serde.toTOML {
     requires = ["setuptools"];
     build-backend = "setuptools.build_meta";
   };
+  tool.setuptools = {
+    include-package-data = true;
+    package-data."*" = ["*.pyi" "*.txt"];
+  };
 }


### PR DESCRIPTION
Add an export for all the dependent file descriptor protos for the generated code. This is useful ofr dynamic applications such as constructing messages from the strings.