### PR TITLE
Avoid updating the flake lock in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,6 +35,7 @@ runs:
       if: ${{ inputs.architecture  == 'x86-64'}}
       run: |
         nix build .#tester_${{ inputs.generator }} \
+        --no-update-lock-file \
         --override-input nix-proto github:notalltim/nix-proto/${{ inputs.branch }} \
         --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} \
         --override-input upstream-apis github:notalltim/upstream-apis/${{ inputs.style }}
@@ -44,6 +45,7 @@ runs:
       if: ${{ inputs.architecture != 'x86-64' }}
       run: |
         nix build .#pkgsCross.${{ inputs.architecture }}.tester_${{ inputs.generator }} \
+        --no-update-lock-file \
         --override-input nix-proto github:notalltim/nix-proto/${{ inputs.branch }} \
         --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} \
         --override-input upstream-apis github:notalltim/upstream-apis/${{ inputs.style }}


### PR DESCRIPTION
The version of nix in the nix action is modifying the lock file when an override is applied. This makes the build fail on the second.