### PR TITLE
switching to lowercase protobuf within the find_dependency call since…

### DIFF
--- a/cpp/grpcConfig.cmake.in
+++ b/cpp/grpcConfig.cmake.in
@@ -3,7 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET protobuf::libprotobuf)
-  find_dependency(Protobuf)
+  find_dependency(protobuf)
 endif()
 
 if(NOT TARGET gRPC::grpc)

--- a/cpp/protoConfig.cmake.in
+++ b/cpp/protoConfig.cmake.in
@@ -3,7 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET protobuf::libprotobuf)
-  find_dependency(Protobuf)
+  find_dependency(protobuf)
 endif()
 
 @GENERATED_FIND_DEPENDENCY@


### PR DESCRIPTION
… for some reason it doesnt like uppercase. :shrug: