### PR TITLE
CI rework to allow for easier collaboration

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,44 +5,72 @@ inputs:
     description: "Branch of repo to build"
     required: true
     default: 'main'
+  repo:
+    description: "Full name of repo formatted as OWNER/REPO"
+    required: false
+    default: "notalltim/nix-proto"
   nixpkgs:
     description: "Branch of nixpkgs to checkout"
     required: true
     default: 'release-23.11'
-  generator:
-    description: "Which generator to build with"
-    required: true
-    default: 'grpc_cpp'
   architecture:
     description: "Architecture to build with"
     required: false
     default: 'x86-64'
+  cache:
+    description: "Use nix magic cache"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Optional cache
+      if: ${{ inputs.cache == 'true' }}
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - uses: actions/checkout@v4
+      with:
+        path: repo
+    - name: Native build
+      if: ${{ inputs.architecture  == 'x86-64'}}
+      run: |
+        nix build .#toplevel_proto_descriptor \
+        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} -L
+        nix build .#toplevel_grpc_cpp \
+        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} -L 
+        nix build .#toplevel_grpc_py \
+        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} -L
+      shell: bash
+      working-directory: repo
+    - name: Cross build
+      if: ${{ inputs.architecture != 'x86-64' }}
+      run: |
+        nix build .#pkgsCross.${{ inputs.architecture }}.toplevel_proto_descriptor \
+        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} -L
+        nix build .#pkgsCross.${{ inputs.architecture }}.toplevel_grpc_cpp \
+        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} -L 
+        nix build .#pkgsCross.${{ inputs.architecture }}.toplevel_grpc_py \
+        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} -L
+      shell: bash
+      working-directory: repo
+    - uses: actions/checkout@v4
+      if: ${{ inputs.architecture  == 'x86-64'}}
       with:
         repository: notalltim/test-apis
         ref: refs/heads/main
         path: test-repo
-    - name: Native build
+    - name: Test API
       if: ${{ inputs.architecture  == 'x86-64'}}
       run: |
-        nix build .#tester_${{ inputs.generator }} \
-        --override-input nix-proto github:notalltim/nix-proto/${{ inputs.branch }} \
-        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} \
-        --override-input upstream-apis github:notalltim/upstream-apis
-      shell: bash
-      working-directory: test-repo
-    - name: Cross build
-      if: ${{ inputs.architecture != 'x86-64' }}
-      run: |
-        nix build .#pkgsCross.${{ inputs.architecture }}.tester_${{ inputs.generator }} \
-        --override-input nix-proto github:notalltim/nix-proto/${{ inputs.branch }} \
-        --override-input nixpkgs github:NixOS/nixpkgs/${{ inputs.nixpkgs }} \
-        --override-input upstream-apis github:notalltim/upstream-apis
+        nix build .#tester_proto_descriptor \
+        --override-input nix-proto github:${{ inputs.repo }}/${{ inputs.branch }} \
+        --override-input upstream-apis github:notalltim/upstream-apis -L
+        nix build .#tester_grpc_cpp \
+        --override-input nix-proto github:${{ inputs.repo }}/${{ inputs.branch }} \
+        --override-input upstream-apis github:notalltim/upstream-apis -L
+        nix build .#tester_grpc_py \
+        --override-input nix-proto github:${{ inputs.repo }}/${{ inputs.branch }} \
+        --override-input upstream-apis github:notalltim/upstream-apis -L
       shell: bash
       working-directory: test-repo
     - uses: actions/checkout@v4

--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -1,0 +1,15 @@
+name: "Check format"
+description: "check the formatting of the nix code"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: actions/checkout@v4
+    - name: "Format"
+      run: nix flake check
+      shell: bash
+    - uses: actions/checkout@v4
+      with:
+        path: action
+

--- a/.github/workflows/aarch64-multiplatform.yml
+++ b/.github/workflows/aarch64-multiplatform.yml
@@ -1,11 +1,15 @@
 name: "aarch64-multiplatform "
 on:
   schedule:
-    - cron: '12 6 * * *'
+    - cron: '12 4 * * *'
   workflow_dispatch:
 jobs:
   build-releases:
+    strategy:
+      matrix:
+        releases: [release-24.05,release-24.11]
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: release-24.05
-      architecture: armv7l-hf-multiplatform
+      nixpkgs: ${{ matrix.releases }}
+      architecture: aarch64-multiplatform
+      cache: "true"

--- a/.github/workflows/armv7-hf-multiplatform.yml
+++ b/.github/workflows/armv7-hf-multiplatform.yml
@@ -1,11 +1,15 @@
 name: "armv7-hf-multiplatform "
 on:
   schedule:
-    - cron: '12 6 * * *'
+    - cron: '12 4 * * *'
   workflow_dispatch:
 jobs:
   build-releases:
+    strategy:
+      matrix:
+        releases: [release-24.05,release-24.11]
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: release-24.05
+      nixpkgs: ${{ matrix.releases }}
       architecture: armv7l-hf-multiplatform
+      cache: "true"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,26 +1,15 @@
-name: Build multiple
+name: Format check
 on:
   workflow_call:
     inputs:
-      nixpkgs:
-        required: true
-        type: string
       repo:
         required: false
         type: string
         default: "notalltim/nix-proto"
-      architecture:
-        type: string
-        required: false
-        default: "x86-64"
       branch:
         type: string
         required: false
         default: "main"
-      cache:
-        type: string
-        required: false
-        default: "false"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,11 +26,5 @@ jobs:
           sparse-checkout: .github
           path: action
           ref: refs/heads/main
-      - name: Build
-        uses: ./action/.github/actions/build
-        with:
-          nixpkgs: ${{ inputs.nixpkgs }}
-          branch: ${{ inputs.branch }}
-          architecture: ${{ inputs.architecture }}
-          repo: ${{ inputs.repo }}
-          cache: ${{ inputs.cache }}
+      - name: Format
+        uses: ./action/.github/actions/format

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,4 +7,5 @@ jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: master
+      nixpkgs: master
+      cache: "true"

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -4,28 +4,40 @@ on:
     branches:
       - main
 jobs:
-  build-supported-releases:
-    strategy:
-      matrix:
-        branches: [release-23.05, release-23.11, release-24.05, nixpkgs-unstable, master]
-    uses: ./.github/workflows/build-multiple.yml
-    with:
-      branch: ${{ matrix.branches }}
   build-supported-cross:
     strategy:
       matrix:
-        branches: [release-24.05]
+        releases: [release-24.05, release-24.11]
         architectures: [armv7l-hf-multiplatform, aarch64-multiplatform]
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: ${{ matrix.branches }}
+      nixpkgs: ${{ matrix.releases }}
       architecture: ${{ matrix.architectures }}
+      repo: ${{ github.event.pull_request.head.repo.full_name }}
+      branch: ${{ github.event.pull_request.head.ref }}
+      cache: "true"
+  build-supported-releases:
+    strategy:
+      matrix:
+        releases: [release-23.11, release-24.05, release-24.11, nixpkgs-unstable, master]
+    uses: ./.github/workflows/build-multiple.yml
+    with:
+      nixpkgs: ${{ matrix.releases }}
+      repo: ${{ github.event.pull_request.head.repo.full_name }}
+      branch: ${{ github.event.pull_request.head.ref }}
+  # check-format:
+  #   uses: ./.github/workflows/format.yml
+  #   with:
+  #     repo: ${{ github.event.pull_request.head.repo.full_name }}
+  #     branch: ${{ github.event.pull_request.head.ref }}
+
   it-all-good:
     runs-on: ubuntu-latest
     if: always()
     needs:
       - build-supported-releases
       - build-supported-cross
+      # - check-format
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/release-23.11.yml
+++ b/.github/workflows/release-23.11.yml
@@ -7,4 +7,5 @@ jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: release-23.11
+      nixpkgs: release-23.11
+      cache: "true"

--- a/.github/workflows/release-24.05.yml
+++ b/.github/workflows/release-24.05.yml
@@ -7,4 +7,5 @@ jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: release-24.05
+      nixpkgs: release-24.05
+      cache: "true"

--- a/.github/workflows/release-24.11.yml
+++ b/.github/workflows/release-24.11.yml
@@ -1,8 +1,11 @@
-name: "23.05 "
+name: "24.11 "
 on:
+  schedule:
+    - cron: '12 6 * * *'
   workflow_dispatch:
 jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: release-23.05
+      nixpkgs: release-24.11
+      cache: "true"

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -7,4 +7,5 @@ jobs:
   build-releases:
     uses: ./.github/workflows/build-multiple.yml
     with:
-      branch: nixpkgs-unstable
+      nixpkgs: nixpkgs-unstable
+      cache: "true"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The nix-proto library provides automatic overlay generation and dependency manag
 
 ## Supported Releases
 
-![release-23.05](https://github.com/notalltim/nix-proto/actions/workflows/release-23.05.yml/badge.svg) ![release-23.11](https://github.com/notalltim/nix-proto/actions/workflows/release-23.11.yml/badge.svg) ![release-24.05](https://github.com/notalltim/nix-proto/actions/workflows/release-24.05.yml/badge.svg) ![unstable](https://github.com/notalltim/nix-proto/actions/workflows/unstable.yml/badge.svg) ![master](https://github.com/notalltim/nix-proto/actions/workflows/master.yml/badge.svg)
+![release-23.11](https://github.com/notalltim/nix-proto/actions/workflows/release-23.11.yml/badge.svg) ![release-24.05](https://github.com/notalltim/nix-proto/actions/workflows/release-24.05.yml/badge.svg) ![release-24.11](https://github.com/notalltim/nix-proto/actions/workflows/release-24.11.yml/badge.svg) ![unstable](https://github.com/notalltim/nix-proto/actions/workflows/unstable.yml/badge.svg) ![master](https://github.com/notalltim/nix-proto/actions/workflows/master.yml/badge.svg)
 
 ## Supported Cross Compile
 
-**NOTE** only tested with `x86_64-linux` as the `buildPlatform` on `nixpkgs-24.05`
+**NOTE** only tested with `x86_64-linux` as the `buildPlatform` on `nixpkgs-24.05` and `nixpkgs-24.11`
 
 ![aarch64-multiplatform](https://github.com/notalltim/nix-proto/actions/workflows/aarch64-multiplatform.yml/badge.svg) ![armv7-hf-multiplatform](https://github.com/notalltim/nix-proto/actions/workflows/armv7-hf-multiplatform.yml/badge.svg)
 

--- a/cpp/CMakeLists.txt.grpc
+++ b/cpp/CMakeLists.txt.grpc
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.12)
 
 project(${CPP_NAME} VERSION "${CPP_VERISON}")
 
-find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 if(DEFINED Protobuf_PROTOC_EXECUTABLE)
   message("Overriding protoc to ${Protobuf_PROTOC_EXECUTABLE}")

--- a/cpp/default.nix
+++ b/cpp/default.nix
@@ -165,7 +165,7 @@
 
       # There is a problem with newer version of Protobuf when generating GRPC code that causes a build failure without adding a local dir to the list of includes for the proto generation
       preConfigure = ''
-        cmakeFlags="-DPROTO_DEPS=${(toProtoDepsCMake ((recursiveProtoDeps meta.protoDeps) ++ [meta]))};$PWD $cmakeFlags"
+        cmakeFlags="-DPROTO_DEPS=${(toProtoDepsCMake ((recursiveProtoDeps meta.protoDeps)))};$PWD $cmakeFlags"
       '';
 
       outputs = ["out" "dev"];

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,5 @@
   generation = import ./generation.nix {inherit lib;};
 in {
   inherit (generation) mkProtoDerivation generateOverlays';
-  lib = {
-    inherit (utilities) srcFromNamespace nameFromNamespace overlayToList;
-  };
+  inherit (utilities) srcFromNamespace nameFromNamespace overlayToList;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,30 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
         "type": "github"
       },
       "original": {
@@ -32,11 +50,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719426051,
-        "narHash": "sha256-yJL9VYQhaRM7xs0M867ZFxwaONB9T2Q4LnGo1WovuR4=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89c49874fb15f4124bf71ca5f42a04f2ee5825fd",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
@@ -46,11 +64,45 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nix-filter": "nix-filter",
         "nix-std": "nix-std",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737483750,
+        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,20 +3,41 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     nix-std.url = "github:chessai/nix-std";
     nix-filter.url = "github:numtide/nix-filter";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    treefmt-nix = { 
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
-  outputs = {
-    nixpkgs,
-    nix-std,
-    nix-filter,
-    ...
-  }: let
-    std = nix-std.lib;
-    nix_lib = nixpkgs.lib;
-    filter = nix-filter.lib;
-  in
-    (import ./.) {
-      inherit nix_lib;
-      inherit std;
-      inherit filter;
+  outputs = inputs@{ self,flake-parts, ... }:
+  flake-parts.lib.mkFlake { inherit inputs; } {
+    imports = [
+      inputs.treefmt-nix.flakeModule
+    ];
+    flake = 
+      let lib =  (import ./.) {
+      nix_lib = inputs.nixpkgs.lib;
+      std = inputs.nix-std.lib;
+      filter = inputs.nix-filter.lib;
+    };
+    in {
+      inherit lib;
+      inherit (lib) mkProtoDerivation generateOverlays';
+      overlays = import ./test/overlays.nix lib;
+    };     
+    systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+    perSystem = { pkgs, system, ... }: {
+       _module.args.pkgs = import inputs.nixpkgs  {
+          inherit system;
+          overlays = builtins.attrValues self.overlays;
+        };
+        legacyPackages = pkgs;
+        formatter = pkgs.nixfmt-rfc-style;
+        treefmt.programs = {
+          nixfmt-rfc-style.enable = true;
+          yamlfmt.enable = true;
+          protolint.enable = true;
+        };
+  };
     };
 }

--- a/test/overlays.nix
+++ b/test/overlays.nix
@@ -1,0 +1,70 @@
+nix-proto:
+let
+  upstream = nix-proto.generateOverlays' {
+    namespaced = nix-proto.mkProtoDerivation {
+      name = "namespaced";
+      src = nix-proto.srcFromNamespace {
+        root = ./proto;
+        namespace = "outer/inner/namespaced";
+      };
+      version = "1.0.0";
+      protoDeps = [ ];
+    };
+    upstream =
+      {
+        namespaced,
+        unnamespaced,
+      }:
+      nix-proto.mkProtoDerivation {
+        name = "upstream";
+        src = nix-proto.srcFromNamespace {
+          root = ./proto;
+          namespace = "upstream";
+        };
+        version = "1.0.0";
+        protoDeps = [
+          namespaced
+          unnamespaced
+        ];
+      };
+    unnamespaced = nix-proto.mkProtoDerivation {
+      name = "unnamespaced";
+      src = ./proto/unnamespaced;
+      version = "0.0.0";
+      protoDeps = [ ];
+    };
+  };
+
+  user = nix-proto.generateOverlays' {
+    middle =
+      { upstream }:
+      nix-proto.mkProtoDerivation {
+        name = "middle";
+        src = nix-proto.srcFromNamespace {
+          root = ./proto;
+          namespace = "middle";
+        };
+        version = "1.0.0";
+        protoDeps = [ upstream ];
+      };
+
+    toplevel =
+      {
+        upstream,
+        middle,
+      }:
+      nix-proto.mkProtoDerivation {
+        name = "toplevel";
+        src = nix-proto.srcFromNamespace {
+          root = ./proto;
+          namespace = "toplevel";
+        };
+        version = "1.0.0";
+        protoDeps = [
+          upstream
+          middle
+        ];
+      };
+  };
+in
+upstream // user

--- a/test/proto/middle/v1/message/data.proto
+++ b/test/proto/middle/v1/message/data.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+import "upstream/v1/message/data.proto";
+package middle.v1.message;
+
+message Data {
+  double data = 1;
+  upstream.v1.message.Data upstream_data = 2;
+}

--- a/test/proto/middle/v1/service/test_service.proto
+++ b/test/proto/middle/v1/service/test_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+import "middle/v1/message/data.proto";
+
+package test.v1.service;
+
+message Request {
+  uint32 id = 1;
+}
+
+message Response {
+  uint32 id = 1;
+  middle.v1.message.Data data = 2;
+}
+
+service TestService {
+  rpc getResponse (Request) returns (Response);
+}

--- a/test/proto/outer/inner/namespaced/test/v1/test.proto
+++ b/test/proto/outer/inner/namespaced/test/v1/test.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package outer.inner.namespaced.test.v1;
+
+message NamedData {
+  double data = 1;
+}

--- a/test/proto/toplevel/v2/message/data.proto
+++ b/test/proto/toplevel/v2/message/data.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package toplevel.v2.message;
+import "middle/v1/message/data.proto";
+
+
+message DataTest {
+  double data = 1;
+  middle.v1.message.Data this = 2;
+}

--- a/test/proto/toplevel/v2/message/toplevel.proto
+++ b/test/proto/toplevel/v2/message/toplevel.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package toplevel.v2.message;
+import "google/protobuf/any.proto";
+import "toplevel/v2/message/data.proto";
+
+
+message ToplevelMessage {
+  double data = 1;
+  google.protobuf.Any test = 2;
+  toplevel.v2.message.DataTest test_data = 3;
+}

--- a/test/proto/toplevel/v2/service/toplevel_service.proto
+++ b/test/proto/toplevel/v2/service/toplevel_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package toplevel.v2.message;
+import "toplevel/v2/message/toplevel.proto";
+
+message Request { 
+  uint32 id = 1; 
+}
+
+message Response {
+  uint32 id = 1;
+  ToplevelMessage data = 2;
+}
+
+service TestService {
+  rpc GetResponse(Request) returns (Response);
+  rpc GetResponseStream(Request) returns (stream Response);
+}

--- a/test/proto/unnamespaced/unnamespace_service.proto
+++ b/test/proto/unnamespaced/unnamespace_service.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+import "unnamespaced.proto";
+
+
+message Request {
+  uint32 id = 1;
+}
+
+message Response {
+  uint32 id = 1;
+  Data data = 2;
+}
+
+service TestService {
+  rpc GetResponse (Request) returns (Response);
+}

--- a/test/proto/unnamespaced/unnamespaced.proto
+++ b/test/proto/unnamespaced/unnamespaced.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Data {
+  double data = 1;
+}

--- a/test/proto/upstream/v1/message/data.proto
+++ b/test/proto/upstream/v1/message/data.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package upstream.v1.message;
+
+message Data {
+  double data = 1;
+}

--- a/test/proto/upstream/v1/message/message.proto
+++ b/test/proto/upstream/v1/message/message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package upstream.v1.message;
+
+import "unnamespaced.proto";
+import "upstream/v1/message/data.proto";
+
+message Thing {
+  Data data = 1;
+}

--- a/test/proto/upstream/v1/service/test_service.proto
+++ b/test/proto/upstream/v1/service/test_service.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package upstream.v1.service;
+
+import "outer/inner/namespaced/test/v1/test.proto";
+import "upstream/v1/message/data.proto";
+
+message Request {
+  uint32 id = 1;
+}
+
+message Response {
+  uint32 id = 1;
+  upstream.v1.message.Data data = 2;
+  outer.inner.namespaced.test.v1.NamedData named_data = 3;
+}
+
+service TestService {
+  rpc GetResponse (Request) returns (Response);
+}


### PR DESCRIPTION
Through this PR I reworked the CI to improve the legibility and
coverage. The main test data is in repo and the flake has been reworked
to user `flake-parts`. The old CI method is preserved as an API check
and example. This also supports forks as a place to build from.
Addtionally I added formatting for nix, yaml, and proto.

* Small fix for C++ build for newer versions of protobuf