### PR TITLE
Fix evaluation warnings / spelling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1762040540,
+        "narHash": "sha256-z5PlZ47j50VNF3R+IMS9LmzI5fYRGY/Z5O5tol1c9I4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "0010412d62a25d959151790968765a70c436598b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1731533336,
-        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754767907,
-        "narHash": "sha256-8OnUzRQZkqtUol9vuUuQC30hzpMreKptNyET2T9lB6g=",
+        "lastModified": 1762127720,
+        "narHash": "sha256-dAxyYBQyGVGGxuDafeWUBMH7vmN0pAMQ9SrRrYcmqtI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5f08b62ed75415439d48152c2a784e36909b1bc",
+        "rev": "d9968349cef4c57d9c67702b294056ff1236154d",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754492133,
-        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
+        "lastModified": 1761311587,
+        "narHash": "sha256-Msq86cR5SjozQGCnC6H8C+0cD4rnx91BPltZ9KK613Y=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
+        "rev": "2eddae033e4e74bf581c2d1dfa101f9033dbd2dc",
         "type": "github"
       },
       "original": {

--- a/generation.nix
+++ b/generation.nix
@@ -325,7 +325,7 @@ rec {
         in
         nameValuePair key (
           nixProtoWarn
-            "Accessing ${key} directly is deperacted use python3Packages.${key}. Specific python package sets are also supported e.g. python310Packages"
+            "Accessing ${key} directly is deprecated use python3Packages.${key}. Specific python package sets are also supported e.g. python310Packages"
             final.python3Packages.${key}
         )
       ) pythonOverlayDrvs;

--- a/python/default.nix
+++ b/python/default.nix
@@ -141,7 +141,7 @@ rec {
       __proto_internal_meta_package,
       python,
       substituteAll ? null,
-      replaceVars ? null,
+      replaceVars ? _: _: builtins.throw "Missing replaceVars",
       writeTextFile,
     }:
     let
@@ -159,18 +159,13 @@ rec {
 
       # Generate each proto file using protoc and add the generated code to the __init__.py file to allow for top level imports
       descriptor_py =
-        if
-          (tryEval (substituteAll {
-            src = ./descriptor.py;
-            package = protoMeta.name + "_proto_py";
-          })).success
-        then
+        if (tryEval (replaceVars ./descriptor.py { package = protoMeta.name + "_proto_py"; })).success then
+          replaceVars ./descriptor.py { package = protoMeta.name + "_proto_py"; }
+        else
           substituteAll {
             src = ./descriptor.py;
             package = protoMeta.name + "_proto_py";
-          }
-        else
-          replaceVars ./descriptor.py { package = protoMeta.name + "_proto_py"; };
+          };
       descriptors = writeTextFile {
         name = "descriptors.txt";
         text = concatStringsSep "\n" (toBuildDepsDescriptor fullProtoDeps pkgs);


### PR DESCRIPTION
`substitueAll` will be removed in 25.11 and is now a warning. To keep backwards compatibility, we still need `substitueAll` so put it behind a `tryEval` and make `replaceVars` the default.

* Fix `substitueAll` eval warning
* Fix spelling in python eval warning
* Bump the flake lock